### PR TITLE
added option to run events after animation

### DIFF
--- a/animatefx/src/main/java/animatefx/animation/AnimationFX.java
+++ b/animatefx/src/main/java/animatefx/animation/AnimationFX.java
@@ -181,4 +181,13 @@ public abstract class AnimationFX {
         return this;
     }
 
+    /**
+     * Set event when the animation ended.
+     *
+     * @param value
+     */
+    public final void setOnFinished(EventHandler<ActionEvent> value) {
+        this.timeline.setOnFinished(value);
+    }
+
 }

--- a/animatefx/src/main/java/animatefx/animation/AnimationFX.java
+++ b/animatefx/src/main/java/animatefx/animation/AnimationFX.java
@@ -2,6 +2,8 @@ package animatefx.animation;
 
 import javafx.animation.Animation;
 import javafx.animation.Timeline;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.util.Duration;
 


### PR DESCRIPTION
Added a feature that allows to run events after an animation timeline is done. This way I can use 
``` 
AnimationFX animationFX = new SlideOutRight(GLOBALS.getRootPane().getChildren().get(0));
animationFX.setOnFinished(event -> {
    GLOBALS.getRootPane().getChildren().clear();
  });
animationFX.play();
```
So after the animation is played and the root pane is out of the screen I can remove it. This is just one example.