### PR TITLE
Quick fix to make it work "out of the box"

### DIFF
--- a/animatefx-demo/build.gradle
+++ b/animatefx-demo/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'application'
+plugins {
+    id 'application'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
+}
 
 mainClassName = "animatefx.demo.Main"
 
@@ -12,6 +15,11 @@ targetCompatibility=1.8
 dependencies {
     compile project(":animatefx")
 
+}
+
+javafx {
+    version = "11"
+    modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web' ]
 }
 
 jar {

--- a/animatefx/build.gradle
+++ b/animatefx/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id "com.jfrog.artifactory" version"4.7.3"
     id "maven-publish"
     id "java"
+    id 'application'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 repositories {
@@ -13,6 +15,11 @@ version = '1.2.2' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHO
 sourceCompatibility = 1.8
 
 dependencies {
+}
+
+javafx {
+    version = "11"
+    modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web' ]
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
Maybe it's a good idea to make the project ready for compiling right after clone.
What I use in my projects is the openjfx plugin to setup JavaFX for Gradle (as stated here too [Getting Started](https://openjfx.io/openjfx-docs/#gradle)).
I used amazon corretto jdk 11 (downloaded automatically by intellij) and javafx 11 but I usually use jdk14 and javafx 14