### PR TITLE
Add partial animation "Expand" and "Contract", which can be used together

### DIFF
--- a/animatefx/src/main/java/animatefx/animation/AnimationFX.java
+++ b/animatefx/src/main/java/animatefx/animation/AnimationFX.java
@@ -105,12 +105,12 @@ public abstract class AnimationFX {
      *
      * @return
      */
-    abstract AnimationFX resetNode();
+    protected abstract AnimationFX resetNode();
 
     /**
      * Function to initialize the timeline
      */
-    abstract void initTimeline();
+    protected abstract void initTimeline();
 
 
     public Timeline getTimeline() {

--- a/animatefx/src/main/java/animatefx/animation/Bounce.java
+++ b/animatefx/src/main/java/animatefx/animation/Bounce.java
@@ -34,7 +34,7 @@ public class Bounce extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(
                 new Timeline(
 

--- a/animatefx/src/main/java/animatefx/animation/BounceIn.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceIn.java
@@ -28,7 +28,7 @@ public class BounceIn extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -36,7 +36,7 @@ public class BounceIn extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 0, Interpolator.SPLINE(0.215, 0.610, 0.355, 1.000)),

--- a/animatefx/src/main/java/animatefx/animation/BounceInDown.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceInDown.java
@@ -25,14 +25,14 @@ public class BounceInDown extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         this.setTimeline(new Timeline(
 
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/BounceInLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceInLeft.java
@@ -25,14 +25,14 @@ public class BounceInLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         double startX = -getNode().localToScene(0, 0).getX() - getNode().getBoundsInParent().getWidth();
        setTimeline(
                 new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/BounceInRight.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceInRight.java
@@ -25,14 +25,14 @@ public class BounceInRight extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
 
         double startX = getNode().getScene().getWidth() - getNode().localToScene(0, 0).getX();
         setTimeline(

--- a/animatefx/src/main/java/animatefx/animation/BounceInUp.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceInUp.java
@@ -25,14 +25,14 @@ public class BounceInUp extends AnimationFX{
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         double startY = getNode().getScene().getHeight() - getNode().localToScene(0, 0).getY();
         setTimeline( new Timeline(
                         new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/BounceOut.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceOut.java
@@ -24,7 +24,7 @@ public class BounceOut extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -32,7 +32,7 @@ public class BounceOut extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
 
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/BounceOutDown.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceOutDown.java
@@ -24,14 +24,14 @@ public class BounceOutDown extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         double endY = getNode().getScene().getHeight() - getNode().localToScene(0, 0).getY();
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/BounceOutLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceOutLeft.java
@@ -24,14 +24,14 @@ public class BounceOutLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setTranslateX(0);
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/BounceOutRight.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceOutRight.java
@@ -24,14 +24,14 @@ public class BounceOutRight extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setTranslateX(0);
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/BounceOutUp.java
+++ b/animatefx/src/main/java/animatefx/animation/BounceOutUp.java
@@ -24,14 +24,14 @@ public class BounceOutUp extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setTranslateY(0);
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/FadeIn.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeIn.java
@@ -25,13 +25,13 @@ public class FadeIn extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 0, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/FadeInDown.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeInDown.java
@@ -25,14 +25,14 @@ public class FadeInDown extends AnimationFX{
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 0, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeInDownBig.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeInDownBig.java
@@ -25,14 +25,14 @@ public class FadeInDownBig extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 0, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeInLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeInLeft.java
@@ -25,14 +25,14 @@ public class FadeInLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 0, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeInLeftBig.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeInLeftBig.java
@@ -25,14 +25,14 @@ public class FadeInLeftBig extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
 
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/FadeInRight.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeInRight.java
@@ -25,14 +25,14 @@ public class FadeInRight extends AnimationFX{
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
 
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/FadeInRightBig.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeInRightBig.java
@@ -25,14 +25,14 @@ public class FadeInRightBig extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
 
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/FadeInUp.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeInUp.java
@@ -25,14 +25,14 @@ public class FadeInUp extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
 
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/FadeInUpBig.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeInUpBig.java
@@ -25,14 +25,14 @@ public class FadeInUpBig extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
 
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/FadeOut.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeOut.java
@@ -22,13 +22,13 @@ public class FadeOut extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/FadeOutDown.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeOutDown.java
@@ -25,14 +25,14 @@ public class FadeOutDown extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeOutDownBig.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeOutDownBig.java
@@ -25,14 +25,14 @@ public class FadeOutDownBig extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeOutLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeOutLeft.java
@@ -25,14 +25,14 @@ public class FadeOutLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeOutLeftBig.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeOutLeftBig.java
@@ -25,14 +25,14 @@ public class FadeOutLeftBig extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeOutRight.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeOutRight.java
@@ -25,14 +25,14 @@ public class FadeOutRight extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeOutRightBig.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeOutRightBig.java
@@ -25,14 +25,14 @@ public class FadeOutRightBig extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeOutUp.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeOutUp.java
@@ -25,14 +25,14 @@ public class FadeOutUp extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/FadeOutUpBig.java
+++ b/animatefx/src/main/java/animatefx/animation/FadeOutUpBig.java
@@ -25,14 +25,14 @@ public class FadeOutUpBig extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/Flash.java
+++ b/animatefx/src/main/java/animatefx/animation/Flash.java
@@ -25,13 +25,13 @@ public class Flash extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
 
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/Flip.java
+++ b/animatefx/src/main/java/animatefx/animation/Flip.java
@@ -30,7 +30,7 @@ public class Flip extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setRotate(0);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -40,7 +40,7 @@ public class Flip extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().getScene().setCamera(new PerspectiveCamera());
         getNode().setRotationAxis(Y_AXIS);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/FlipInX.java
+++ b/animatefx/src/main/java/animatefx/animation/FlipInX.java
@@ -30,14 +30,14 @@ public class FlipInX extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setRotate(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().getScene().setCamera(new PerspectiveCamera());
         getNode().setRotationAxis(X_AXIS);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/FlipInY.java
+++ b/animatefx/src/main/java/animatefx/animation/FlipInY.java
@@ -30,14 +30,14 @@ public class FlipInY extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setRotate(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().getScene().setCamera(new PerspectiveCamera());
         getNode().setRotationAxis(Y_AXIS);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/FlipOutX.java
+++ b/animatefx/src/main/java/animatefx/animation/FlipOutX.java
@@ -29,14 +29,14 @@ public class FlipOutX extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setRotate(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().getScene().setCamera(new PerspectiveCamera());
         getNode().setRotationAxis(X_AXIS);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/FlipOutY.java
+++ b/animatefx/src/main/java/animatefx/animation/FlipOutY.java
@@ -29,14 +29,14 @@ public class FlipOutY extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setRotate(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().getScene().setCamera(new PerspectiveCamera());
         getNode().setRotationAxis(Y_AXIS);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/GlowBackground.java
+++ b/animatefx/src/main/java/animatefx/animation/GlowBackground.java
@@ -75,13 +75,13 @@ public class GlowBackground extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setBackground(originalBackground);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline()); //will be populated at the end of constructor
     }
 

--- a/animatefx/src/main/java/animatefx/animation/GlowText.java
+++ b/animatefx/src/main/java/animatefx/animation/GlowText.java
@@ -45,13 +45,13 @@ public class GlowText extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setTextFill(originalPaint);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline()); //will be populated at the end of constructor
     }
 

--- a/animatefx/src/main/java/animatefx/animation/Hinge.java
+++ b/animatefx/src/main/java/animatefx/animation/Hinge.java
@@ -30,7 +30,7 @@ public class Hinge extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         rotate.setAngle(0);
@@ -38,7 +38,7 @@ public class Hinge extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         double endY = getNode().getScene().getHeight() - getNode().localToScene(0, 0).getY();
         rotate = new Rotate(0, 0, 0);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/JackInTheBox.java
+++ b/animatefx/src/main/java/animatefx/animation/JackInTheBox.java
@@ -28,7 +28,7 @@ public class JackInTheBox extends AnimationFX {
     private Rotate rotate;
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setScaleX(1);
         getNode().setScaleZ(1);
         getNode().setScaleY(1);
@@ -38,7 +38,7 @@ public class JackInTheBox extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
          rotate = new Rotate(30, getNode().getBoundsInParent().getWidth() / 2, getNode().getBoundsInParent().getHeight());
         getNode().getTransforms().add(rotate);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/Jello.java
+++ b/animatefx/src/main/java/animatefx/animation/Jello.java
@@ -26,7 +26,7 @@ public class Jello extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         shear.setX(0);
         shear.setY(0);
         return this;
@@ -35,7 +35,7 @@ public class Jello extends AnimationFX {
     private Shear shear;
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
          shear = new Shear();
         Bounds bounds = getNode().getLayoutBounds();
         shear.setPivotX(bounds.getWidth() / 2);

--- a/animatefx/src/main/java/animatefx/animation/LightSpeedIn.java
+++ b/animatefx/src/main/java/animatefx/animation/LightSpeedIn.java
@@ -27,7 +27,7 @@ public class LightSpeedIn extends AnimationFX {
     private  Shear shear;
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         shear.setX(0);
         shear.setY(0);
         getNode().setTranslateX(0);
@@ -36,7 +36,7 @@ public class LightSpeedIn extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
          shear = new Shear();
         getNode().getTransforms().add(shear);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/LightSpeedOut.java
+++ b/animatefx/src/main/java/animatefx/animation/LightSpeedOut.java
@@ -29,7 +29,7 @@ public class LightSpeedOut extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         shear.setX(0);
         shear.setY(0);
         getNode().setOpacity(1);
@@ -38,7 +38,7 @@ public class LightSpeedOut extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         shear = new Shear();
         getNode().getTransforms().add(shear);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/Pulse.java
+++ b/animatefx/src/main/java/animatefx/animation/Pulse.java
@@ -26,7 +26,7 @@ public class Pulse extends AnimationFX {
 
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setScaleX(1);
         getNode().setScaleY(1);
         getNode().setScaleZ(1);
@@ -34,7 +34,7 @@ public class Pulse extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().scaleXProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/RollIn.java
+++ b/animatefx/src/main/java/animatefx/animation/RollIn.java
@@ -25,7 +25,7 @@ public class RollIn extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         getNode().setRotate(0);
@@ -33,7 +33,7 @@ public class RollIn extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 0, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/RollOut.java
+++ b/animatefx/src/main/java/animatefx/animation/RollOut.java
@@ -25,7 +25,7 @@ public class RollOut extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         getNode().setRotate(0);
@@ -33,7 +33,7 @@ public class RollOut extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/RotateIn.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateIn.java
@@ -25,14 +25,14 @@ public class RotateIn extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setRotate(0);
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().setRotationAxis(Rotate.Z_AXIS);
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/RotateInDownLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateInDownLeft.java
@@ -26,14 +26,14 @@ public class RotateInDownLeft extends AnimationFX {
     private Rotate rotate;
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         rotate.setAngle(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().setRotationAxis(Rotate.Z_AXIS);
          rotate = new Rotate(0, 0, getNode().getBoundsInLocal().getHeight());
         getNode().getTransforms().add(rotate);

--- a/animatefx/src/main/java/animatefx/animation/RotateInDownRight.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateInDownRight.java
@@ -27,14 +27,14 @@ public class RotateInDownRight extends AnimationFX {
     private  Rotate rotate;
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         rotate.setAngle(0);
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().setRotationAxis(Rotate.Z_AXIS);
         rotate = new Rotate(0, getNode().getBoundsInLocal().getWidth(), getNode().getBoundsInLocal().getHeight());
         getNode().getTransforms().add(rotate);

--- a/animatefx/src/main/java/animatefx/animation/RotateInUpLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateInUpLeft.java
@@ -27,14 +27,14 @@ public class RotateInUpLeft extends AnimationFX {
     private Rotate rotate;
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         rotate.setAngle(0);
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().setRotationAxis(Rotate.Z_AXIS);
         rotate = new Rotate(0, 0, getNode().getBoundsInLocal().getHeight());
         getNode().getTransforms().add(rotate);

--- a/animatefx/src/main/java/animatefx/animation/RotateInUpRight.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateInUpRight.java
@@ -27,14 +27,14 @@ public class RotateInUpRight extends AnimationFX {
     private Rotate rotate;
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         rotate.setAngle(0);
         getNode().setOpacity(1);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().setRotationAxis(Rotate.Z_AXIS);
         rotate = new Rotate(0, getNode().getBoundsInLocal().getWidth(), getNode().getBoundsInLocal().getHeight());
         getNode().getTransforms().add(rotate);

--- a/animatefx/src/main/java/animatefx/animation/RotateOut.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateOut.java
@@ -25,14 +25,14 @@ public class RotateOut extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setRotate(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().setRotationAxis(Rotate.Z_AXIS);
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/RotateOutDownLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateOutDownLeft.java
@@ -27,14 +27,14 @@ public class RotateOutDownLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         rotate.setAngle(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().setRotationAxis(Rotate.Z_AXIS);
         rotate = new Rotate(0, 0, getNode().getBoundsInLocal().getHeight());
         getNode().getTransforms().add(rotate);

--- a/animatefx/src/main/java/animatefx/animation/RotateOutDownRight.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateOutDownRight.java
@@ -27,14 +27,14 @@ public class RotateOutDownRight extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         rotate.setAngle(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         rotate = new Rotate(0, getNode().getBoundsInLocal().getWidth(), getNode().getBoundsInLocal().getHeight());
         getNode().getTransforms().add(rotate);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/RotateOutUpLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateOutUpLeft.java
@@ -26,14 +26,14 @@ public class RotateOutUpLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         rotate.setAngle(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         rotate = new Rotate(0, 0, getNode().getBoundsInLocal().getHeight());
         getNode().getTransforms().add(rotate);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/RotateOutUpRight.java
+++ b/animatefx/src/main/java/animatefx/animation/RotateOutUpRight.java
@@ -27,14 +27,14 @@ public class RotateOutUpRight extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         rotate.setAngle(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         rotate = new Rotate(0, getNode().getBoundsInLocal().getWidth(), getNode().getBoundsInLocal().getHeight());
         getNode().getTransforms().add(rotate);
         setTimeline(new Timeline(

--- a/animatefx/src/main/java/animatefx/animation/RubberBand.java
+++ b/animatefx/src/main/java/animatefx/animation/RubberBand.java
@@ -26,7 +26,7 @@ public class RubberBand extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setScaleX(1);
         getNode().setScaleY(1);
         getNode().setScaleZ(1);
@@ -34,7 +34,7 @@ public class RubberBand extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().scaleXProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/Shake.java
+++ b/animatefx/src/main/java/animatefx/animation/Shake.java
@@ -25,14 +25,14 @@ public class Shake extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
 
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), 0, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/SlideInDown.java
+++ b/animatefx/src/main/java/animatefx/animation/SlideInDown.java
@@ -25,13 +25,13 @@ public class SlideInDown extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateYProperty(), -getNode().getBoundsInParent().getHeight(), AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/SlideInLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/SlideInLeft.java
@@ -25,13 +25,13 @@ public class SlideInLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), -getNode().getBoundsInParent().getWidth(), AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/SlideInRight.java
+++ b/animatefx/src/main/java/animatefx/animation/SlideInRight.java
@@ -25,13 +25,13 @@ public class SlideInRight extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), getNode().getBoundsInParent().getWidth(), AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/SlideInUp.java
+++ b/animatefx/src/main/java/animatefx/animation/SlideInUp.java
@@ -25,13 +25,13 @@ public class SlideInUp extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateYProperty(), getNode().getBoundsInParent().getHeight(), AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/SlideOutDown.java
+++ b/animatefx/src/main/java/animatefx/animation/SlideOutDown.java
@@ -25,14 +25,14 @@ public class SlideOutDown extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
       setTimeline(  new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateYProperty(), 0, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/SlideOutLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/SlideOutLeft.java
@@ -25,14 +25,14 @@ public class SlideOutLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), 0, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/SlideOutRight.java
+++ b/animatefx/src/main/java/animatefx/animation/SlideOutRight.java
@@ -25,14 +25,14 @@ public class SlideOutRight extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateX(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), 0, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/SlideOutUp.java
+++ b/animatefx/src/main/java/animatefx/animation/SlideOutUp.java
@@ -25,14 +25,14 @@ public class SlideOutUp extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setTranslateY(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateYProperty(), 0, AnimateFXInterpolator.EASE)

--- a/animatefx/src/main/java/animatefx/animation/Swing.java
+++ b/animatefx/src/main/java/animatefx/animation/Swing.java
@@ -27,13 +27,13 @@ public class Swing extends AnimationFX {
     private Rotate rotation;
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         rotation.setAngle(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         rotation = new Rotate();
         rotation.setPivotX(getNode().getLayoutBounds().getWidth() / 2.0);
         rotation.setPivotY(-getNode().getLayoutBounds().getHeight());

--- a/animatefx/src/main/java/animatefx/animation/Tada.java
+++ b/animatefx/src/main/java/animatefx/animation/Tada.java
@@ -25,7 +25,7 @@ public class Tada extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setScaleX(1);
         getNode().setScaleY(1);
         getNode().setScaleZ(1);
@@ -34,7 +34,7 @@ public class Tada extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         getNode().setRotationAxis(Rotate.Z_AXIS);
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),

--- a/animatefx/src/main/java/animatefx/animation/Wobble.java
+++ b/animatefx/src/main/java/animatefx/animation/Wobble.java
@@ -24,14 +24,14 @@ public class Wobble extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setTranslateX(0);
         getNode().setRotate(0);
         return this;
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), 0, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/ZoomIn.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomIn.java
@@ -25,7 +25,7 @@ public class ZoomIn extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
     getNode().setOpacity(1);
     getNode().setScaleX(1);
     getNode().setScaleY(1);
@@ -34,7 +34,7 @@ public class ZoomIn extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 0, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/ZoomInDown.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomInDown.java
@@ -26,7 +26,7 @@ public class ZoomInDown extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -36,7 +36,7 @@ public class ZoomInDown extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 0, Interpolator.SPLINE(0.55, 0.055, 0.675, 0.19)),

--- a/animatefx/src/main/java/animatefx/animation/ZoomInLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomInLeft.java
@@ -26,7 +26,7 @@ public class ZoomInLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -36,7 +36,7 @@ public class ZoomInLeft extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), -1000, Interpolator.SPLINE(0.55, 0.055, 0.675, 0.19)),

--- a/animatefx/src/main/java/animatefx/animation/ZoomInRight.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomInRight.java
@@ -26,7 +26,7 @@ public class ZoomInRight extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -36,7 +36,7 @@ public class ZoomInRight extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), 1000, Interpolator.SPLINE(0.55, 0.055, 0.675, 0.19)),

--- a/animatefx/src/main/java/animatefx/animation/ZoomInUp.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomInUp.java
@@ -26,7 +26,7 @@ public class ZoomInUp extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
 
         getNode().setOpacity(1);
         getNode().setScaleX(1);
@@ -37,7 +37,7 @@ public class ZoomInUp extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 0, Interpolator.SPLINE(0.55, 0.055, 0.675, 0.19)),

--- a/animatefx/src/main/java/animatefx/animation/ZoomOut.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomOut.java
@@ -25,7 +25,7 @@ public class ZoomOut extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -34,7 +34,7 @@ public class ZoomOut extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/ZoomOutDown.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomOutDown.java
@@ -25,7 +25,7 @@ public class ZoomOutDown extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -35,7 +35,7 @@ public class ZoomOutDown extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/ZoomOutLeft.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomOutLeft.java
@@ -25,7 +25,7 @@ public class ZoomOutLeft extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -35,7 +35,7 @@ public class ZoomOutLeft extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), 0, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/ZoomOutRight.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomOutRight.java
@@ -25,7 +25,7 @@ public class ZoomOutRight extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -35,7 +35,7 @@ public class ZoomOutRight extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().translateXProperty(), 0, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/ZoomOutUp.java
+++ b/animatefx/src/main/java/animatefx/animation/ZoomOutUp.java
@@ -25,7 +25,7 @@ public class ZoomOutUp extends AnimationFX {
     }
 
     @Override
-    AnimationFX resetNode() {
+    protected AnimationFX resetNode() {
         getNode().setOpacity(1);
         getNode().setScaleX(1);
         getNode().setScaleY(1);
@@ -35,7 +35,7 @@ public class ZoomOutUp extends AnimationFX {
     }
 
     @Override
-    void initTimeline() {
+    protected void initTimeline() {
         setTimeline(new Timeline(
                 new KeyFrame(Duration.millis(0),
                         new KeyValue(getNode().opacityProperty(), 1, AnimateFXInterpolator.EASE),

--- a/animatefx/src/main/java/animatefx/animation/partial/Contract.java
+++ b/animatefx/src/main/java/animatefx/animation/partial/Contract.java
@@ -1,0 +1,96 @@
+package animatefx.animation.partial;
+
+import animatefx.animation.AnimateFXInterpolator;
+import animatefx.animation.AnimationFX;
+import javafx.animation.KeyFrame;
+import javafx.animation.KeyValue;
+import javafx.animation.Timeline;
+import javafx.scene.Node;
+import javafx.util.Duration;
+
+/**
+ * Can be used in combination with Expand,
+ * to bring the Node back to the original scale.
+ *
+ * @author Dominik Müka aka 41zu
+ */
+public class Contract extends AnimationFX {
+
+    private boolean initialzed;
+    private Number beginScale;
+    private Number endScale;
+
+    /**
+     * Contracts the Node by an defined scale.<br>
+     * The default values are:<br>
+     * beginScale = 1.05<br>
+     * endScale = 1.0
+     *
+     * @param node Node which should be contracted
+     */
+    public Contract(Node node) {
+        super(node);
+    }
+
+    /*
+     * we have to initialize the class variables in this
+     * method, because otherwise they would be initialized
+     * after the constructor and they would be null in the
+     * initTimeline method.
+     */
+    private void initVars() {
+        beginScale = 1.05d;
+        endScale = 1.0d;
+
+        initialzed = true;
+    }
+
+    public Contract setBeginScale(Number beginScale) {
+        this.beginScale = beginScale;
+        rebuildTimeline();
+        return this;
+    }
+
+    public Contract setEndScale(Number endScale) {
+        this.endScale = endScale;
+        rebuildTimeline();
+        return this;
+    }
+
+    /**
+     * resets the Node to the beginScale value
+     */
+    @Override
+    protected AnimationFX resetNode() {
+        getNode().setScaleX(beginScale.doubleValue());
+        getNode().setScaleY(beginScale.doubleValue());
+        getNode().setScaleZ(beginScale.doubleValue());
+        return this;
+    }
+
+    @Override
+    protected void initTimeline() {
+        if (!initialzed)
+            initVars();
+
+        setTimeline(new Timeline(
+                new KeyFrame(Duration.millis(0),
+                        new KeyValue(getNode().scaleXProperty(), beginScale, AnimateFXInterpolator.EASE),
+                        new KeyValue(getNode().scaleYProperty(), beginScale, AnimateFXInterpolator.EASE),
+                        new KeyValue(getNode().scaleZProperty(), beginScale, AnimateFXInterpolator.EASE)
+                ),
+                new KeyFrame(Duration.millis(500),
+                        new KeyValue(getNode().scaleXProperty(), endScale, AnimateFXInterpolator.EASE),
+                        new KeyValue(getNode().scaleYProperty(), endScale, AnimateFXInterpolator.EASE),
+                        new KeyValue(getNode().scaleZProperty(), endScale, AnimateFXInterpolator.EASE)
+                )
+        ));
+    }
+
+    /*
+     * rebuild the timeline with the new variable values
+     */
+    private void rebuildTimeline() {
+        setNode(getNode());
+    }
+}

--- a/animatefx/src/main/java/animatefx/animation/partial/Expand.java
+++ b/animatefx/src/main/java/animatefx/animation/partial/Expand.java
@@ -1,0 +1,95 @@
+package animatefx.animation.partial;
+
+import animatefx.animation.AnimateFXInterpolator;
+import animatefx.animation.AnimationFX;
+import javafx.animation.KeyFrame;
+import javafx.animation.KeyValue;
+import javafx.animation.Timeline;
+import javafx.scene.Node;
+import javafx.util.Duration;
+
+/**
+ * Can be used in combination with Contract.
+ *
+ * @author Dominik Müka aka 41zu
+ */
+public class Expand extends AnimationFX {
+
+    private boolean initialzed;
+    private Number beginScale;
+    private Number endScale;
+
+    /**
+     * Expands the Node by an defined scale.<br>
+     * The default values are:<br>
+     * beginScale = 1.0<br>
+     * endScale = 1.05
+     *
+     * @param node Node which should be expanded
+     */
+    public Expand(Node node) {
+        super(node);
+    }
+
+    /*
+     * we have to initialize the class variables in this
+     * method, because otherwise they would be initialized
+     * after the constructor and they would be null in the
+     * initTimeline method.
+     */
+    private void initVars() {
+        beginScale = 1.0d;
+        endScale = 1.05d;
+
+        initialzed = true;
+    }
+
+    public Expand setBeginScale(Number beginScale) {
+        this.beginScale = beginScale;
+        rebuildTimeline();
+        return this;
+    }
+
+    public Expand setEndScale(Number endScale) {
+        this.endScale = endScale;
+        rebuildTimeline();
+        return this;
+    }
+
+    /**
+     * resets the Node to the beginScale value
+     */
+    @Override
+    protected AnimationFX resetNode() {
+        getNode().setScaleX(beginScale.doubleValue());
+        getNode().setScaleY(beginScale.doubleValue());
+        getNode().setScaleZ(beginScale.doubleValue());
+        return this;
+    }
+
+    @Override
+    protected void initTimeline() {
+        if (!initialzed)
+            initVars();
+
+        setTimeline(new Timeline(
+                new KeyFrame(Duration.millis(0),
+                        new KeyValue(getNode().scaleXProperty(), beginScale, AnimateFXInterpolator.EASE),
+                        new KeyValue(getNode().scaleYProperty(), beginScale, AnimateFXInterpolator.EASE),
+                        new KeyValue(getNode().scaleZProperty(), beginScale, AnimateFXInterpolator.EASE)
+                ),
+                new KeyFrame(Duration.millis(500),
+                        new KeyValue(getNode().scaleXProperty(), endScale, AnimateFXInterpolator.EASE),
+                        new KeyValue(getNode().scaleYProperty(), endScale, AnimateFXInterpolator.EASE),
+                        new KeyValue(getNode().scaleZProperty(), endScale, AnimateFXInterpolator.EASE)
+                )
+        ));
+    }
+
+    /*
+     * rebuild the timeline with the new variable values
+     */
+    private void rebuildTimeline() {
+        setNode(getNode());
+    }
+}


### PR DESCRIPTION
for example like this:

```
nodeObj.setOnMouseEntered(e -> new Expand((Node) e.getSource()).play());
nodeObj.setOnMouseExited(e -> new Contract((Node) e.getSource()).play());
```

it is also posible to set the beginScale and endScale:

```
nodeObj.setOnMouseEntered(e -> new Expand((Node) e.getSource()).setEndScale(1.2).play());
nodeObj.setOnMouseExited(e -> new Contract((Node) e.getSource()).setBeginScale(1.2).play());
```

I also created a new sub package "animatefx.animation.partial", but for that to work I had to increase the method visibility of resetNode and initTimeline, which also means that now every class can extend AnimationFX, which is not a bad change in my opinion.

Internally in the classes of Expand and Contract I had to resort to a few workarounds to support the setBeginScale and setEndScale methods, but they are documented in the classes themself.